### PR TITLE
ng2-input-tag fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "core-js": "^2.4.1",
     "firebase": "^3.7.3",
     "moment": "^2.18.1",
-    "ng2-tag-input": "^1.0.5",
+    "ng2-tag-input": "1.0.0",
     "rxjs": "^5.1.0",
     "zone.js": "^0.7.6"
   },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -19,7 +19,7 @@ import { SideBarComponent } from './side-bar/side-bar.component';
 import {DayResolver} from "./shared/model/day.resolver";
 import {DayService} from "./shared/model/day.service";
 import { BlurChangeDirective } from './directives/blur-change.directive';
-import {TagInputModule} from "ng2-tag-input/dist/modules/ng2-tag-input.module";
+import {TagInputModule} from "ng2-tag-input";
 
 @NgModule({
   declarations: [
@@ -38,20 +38,8 @@ import {TagInputModule} from "ng2-tag-input/dist/modules/ng2-tag-input.module";
     HttpModule,
     AngularFireModule.initializeApp(firebaseConfig, authConfig),
     RouterModule.forRoot(routerConfig),
-    ReactiveFormsModule
-
-    // LEARN NOTE: This does not work, it does not find the resources.
-    // I am suspecting I have to configure systemJS somewhere
-    // as stated in the repo (https://www.npmjs.com/package/ng2-tag-input#configuration-for-systemjs-users)
-    // but I have no clue
-    // #1 Why do I have to do this
-    // #2 Where should I inject that data object, I tried typings.d.ts, did not work
-    // #3 Is inporting an external module such a suffering? I have seen a podcast from
-    // half year ago, and it did seem like I have to insert
-    // stuff to random places sometimes. Is this still this chaotic?
-
-    // ,TagInputModule
-
+    ReactiveFormsModule,
+    TagInputModule
   ],
   providers: [DayService, DayResolver, AuthService, AuthGuard],
   bootstrap: [AppComponent]

--- a/src/app/edit-day/edit-day.component.html
+++ b/src/app/edit-day/edit-day.component.html
@@ -19,7 +19,7 @@
     <div>
       Tags:
       <em>This does not work, see app.module.ts</em>
-      <!--<tag-input [(day.tags)]></tag-input>-->
+      <tag-input [(ngModel)]="day.tags"></tag-input>
     </div>
   </div>
 


### PR DESCRIPTION
1.0.0-ra vissza kellett valtani (ezt a fejlesztotol tudom, mert dobtam neki mailt :)) illetve az importot maskent kellett csinalni de ez a pl-ben is ottvan

hasznalatkor [(ngModel)]=“day.tags” a syntax ha 2 way bindingot akarsz csinalni

teszteltem a cuccot ugy tunt mukodik is

#1: hat talan azert mert kapalni nem akarsz :)
#2: nem igazan van ilyesmire szukseged. Az akkor van ha sima js-es libet akarsz integralni pl jquery-t/d3-at (lsd lentebbi cli link(
#3: Systemjs-t es a regi mitikus helyeken szerkesztett angular-cli.json mar nincs

3rd party dependency install annyi, hogy npm install es utana meg esetleg typingot rantod utana. Doksija kicsit el van dugava wiki/stories alatt
https://github.com/angular/angular-cli/wiki/stories-third-party-lib

-----

side note: lehet megérné frissíteni cli-t illetve mostmár megjött ng4 is, elvileg nem szabadna, hogy sokmindenben bekavarjon és ha minden igaz minimál eltérésnek kéne lenni de most mégis ráfutottunk 

egyébként van ilyen: https://angular-update-guide.firebaseapp.com/

----

side note2: a PR-es dolgot kihagytam volna ebből a körből, mert nehezítésnek érzem jelen esetben de érdekes is, úgyhogy próbáljuk ki :)

----

side note3: ha angolul szeretnéd hogy menjen az egész az is működhet, csak az nálam kicsit rozsdás :)